### PR TITLE
Add Event wrapper

### DIFF
--- a/src/event_wrapper/mod.rs
+++ b/src/event_wrapper/mod.rs
@@ -1,0 +1,63 @@
+//! [`bevy::ecs::event::Event`] wrapper for all types so that they can be sent via the event pipeline in [`bevy`].
+//!
+//! [`bevy::ecs::event::Event`]: https://docs.rs/bevy/latest/bevy/ecs/event/trait.Event.html
+
+pub struct Event<T: Send + Sync + 'static> {
+	inner: T,
+}
+
+impl<T: Send + Sync + 'static> bevy::ecs::event::Event for Event<T> {}
+
+impl<T: Send + Sync + 'static> Event<T> {
+	pub fn into_inner(self) -> T {
+		self.inner
+	}
+}
+
+impl<T: Send + Sync + 'static> std::ops::Deref for Event<T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		&self.inner
+	}
+}
+
+impl<T: Send + Sync + 'static> std::ops::DerefMut for Event<T> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.inner
+	}
+}
+
+impl<T: Clone + Send + Sync + 'static> Clone for Event<T> {
+	fn clone(&self) -> Self {
+		Self { inner: self.inner.clone() }
+	}
+}
+
+impl<T: Copy + Send + Sync + 'static> Copy for Event<T> {}
+
+impl<T: std::fmt::Debug + Send + Sync + 'static> std::fmt::Debug for Event<T> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		self.inner.fmt(f)
+	}
+}
+
+impl<T: std::fmt::Display + Send + Sync + 'static> std::fmt::Display for Event<T> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		self.inner.fmt(f)
+	}
+}
+
+impl<T: PartialEq + Send + Sync + 'static> PartialEq for Event<T> {
+	fn eq(&self, other: &Self) -> bool {
+		self.inner.eq(other)
+	}
+}
+
+impl<T: Eq + Send + Sync + 'static> Eq for Event<T> {}
+
+impl<T: std::hash::Hash + Send + Sync + 'static> std::hash::Hash for Event<T> {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		self.inner.hash(state)
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,11 @@
 //! - Tick deferred commands - schedule commands to run at the end of the tick, after all systems have run
 //! - App utility extensions - adds useful methods to a [`bevy::app::App`] used for testing and debugging
 //! - WebSocket communication - sets up everything in order to communicate via WebSockets
+//! - [`bevy::ecs::event::Event`] wrapper for all types so that they can be sent via the event pipeline in [`bevy`]
 //!
 //! [`bevy`]: https://bevyengine.org/
 //! [`bevy::app::App`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html
+//! [`bevy::ecs::event::Event`]: https://docs.rs/bevy/latest/bevy/ecs/event/trait.Event.html
 
 pub mod par_events;
 pub mod defer_delete;
@@ -25,7 +27,8 @@ pub mod logging;
 pub mod auxiliary_index;
 pub mod tick_deferred_commands;
 pub mod ws;
+pub mod event_wrapper;
 
 pub mod prelude {
-	pub use crate::{app_ext::*, auxiliary_index::*, defer_delete::*, logging::*, par_events::*, schedules::*, tick_deferred_commands::*};
+	pub use crate::{app_ext::*, auxiliary_index::*, defer_delete::*, event_wrapper::*, logging::*, par_events::*, schedules::*, tick_deferred_commands::*};
 }


### PR DESCRIPTION
This removes the need for other, not-really-bevy-related crates to have `bevy_ecs` as a dependency.