### PR TITLE
Fix anon disconns

### DIFF
--- a/src/conns/mod.rs
+++ b/src/conns/mod.rs
@@ -248,7 +248,9 @@ fn receive_messages<TReq, TRes, TErr>(
 								disconn_writer.send(crate::event_wrapper::Event::new(wire::Disconnected::new(user_id.0, session_id.0)));
 								log::debug!("user disconnected, no more remaining sessions");
 							} else {
-								log::debug!("user disconnected, {} remaining sessions", remaining);
+								log::debug!("anon user disconnected, {} remaining sessions", remaining);
+								disconn_writer.send(crate::event_wrapper::Event::new(wire::Disconnected::new(user_id.0, session_id.0)));
+
 							}
 
 							commands.entity(entity).insert(Deleted);

--- a/src/conns/mod.rs
+++ b/src/conns/mod.rs
@@ -248,9 +248,8 @@ fn receive_messages<TReq, TRes, TErr>(
 								disconn_writer.send(crate::event_wrapper::Event::new(wire::Disconnected::new(user_id.0, session_id.0)));
 								log::debug!("user disconnected, no more remaining sessions");
 							} else {
-								log::debug!("anon user disconnected, {} remaining sessions", remaining);
 								disconn_writer.send(crate::event_wrapper::Event::new(wire::Disconnected::new(user_id.0, session_id.0)));
-
+								log::debug!("anon user disconnected, {} remaining sessions", remaining);
 							}
 
 							commands.entity(entity).insert(Deleted);


### PR DESCRIPTION
Properly handle disconn, without this target_map does not get updated and the anon entity id is still registered as in game